### PR TITLE
Added url field in setup and expanded gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,33 @@
-.tox
-bin
-.installed
-parts
-develop-eggs
-eggs
-.installed.cfg
-doc/build
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
 
+# OS metadata
+.DS_STORE
+
+# Distribution / packaging
+*.egg-info/
+/build/
+/dist/
+
+# Virtualenv
+/env/
+
+# Buildout
+/bin/
+/develop-eggs/
+/eggs/
+/src/
+/parts/
+/.installed.cfg
+/.mr.developer.cfg
+
+# Unit test / coverage reports
+.cache/
+/.coverage
+/htmlcov
+/.tox
+
+# Sphinx documentation
+/doc/build/

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     keywords='decorator import package',
     author="Martijn Faassen",
     author_email="faassen@startifact.com",
+    url="http://importscan.readthedocs.io",
     license="BSD",
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
- Added url to http://importscan.readthedocs.io in setup.py
- Expanded .gitignore, especially to exclude .pyc and packaging-related files.
