### PR TITLE
Set up QA for importscan

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = importscan/tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+
+python: 3.5
+env:
+    - TOXENV=py27
+    - TOXENV=py33
+    - TOXENV=py34
+    - TOXENV=py35
+    - TOXENV=pypy
+    - TOXENV=pypy3
+    - TOXENV=pep8
+install:
+    - pip install tox
+script:
+    - tox -e $TOXENV

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ CHANGES
 0.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Dropped support for Python 2.6 and added support for Python 3.5.
 
 
 0.1 (2016-03-15)

--- a/importscan/__init__.py
+++ b/importscan/__init__.py
@@ -1,1 +1,1 @@
-from .scan import scan  # pragma: no cover
+from .scan import scan  # noqa

--- a/importscan/tests/fixtures/__init__.py
+++ b/importscan/tests/fixtures/__init__.py
@@ -1,8 +1,10 @@
 calls = 0
 
+
 def call():
     global calls
     calls += 1
+
 
 def reset():
     global calls

--- a/importscan/tests/fixtures/importerror/module2.py
+++ b/importscan/tests/fixtures/importerror/module2.py
@@ -1,1 +1,1 @@
-from .  import certainlynotthere
+from . import certainlynotthere  # noqa

--- a/importscan/tests/fixtures/importerror_handle_error/module2.py
+++ b/importscan/tests/fixtures/importerror_handle_error/module2.py
@@ -1,1 +1,1 @@
-from .  import certainlynotthere
+from . import certainlynotthere  # noqa

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,12 @@ setup(
     classifiers=[
         "Intended Audience :: Developers",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.6",
+        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,18 @@
 [tox]
-envlist = py27,py34,pypy,pypy3
+envlist = py27,py33,py34,py35,pypy,pypy3,pep8
 
 [testenv]
-deps=pytest
-commands=py.test
+deps = -e{toxinidir}[test]
+commands = py.test {posargs}
+
+[testenv:py27]
+commands = py.test --cov importscan {posargs}
+
+[testenv:pep8]
+basepython = python2
+deps = {[testenv]deps}
+       flake8
+commands = flake8 importscan setup.py
+
+[pytest]
+testpaths = importscan


### PR DESCRIPTION
- Set up Flake8
- Set up coverage
- Set up Travis
- Added Python 3.3, 3.5, PyPy3, pep8 environments to tox.ini
- Dropped support for Python 2.6 in setup.py and declared support for python 3.5.
- Ensured that the supported Python versions are all tested by Tox.
