### PR TITLE
add support for passing module names

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,7 @@ CHANGES
 
 - Clean up the development and release workflow.
 
+- add support for passing a module name as string to enable ``scan(__name__)``
 
 0.1 (2016-03-15)
 ----------------

--- a/importscan/scan.py
+++ b/importscan/scan.py
@@ -20,6 +20,7 @@ def scan(package, ignore=None, handle_error=None):
     decorators.
 
     :param package: A reference to a Python package or module object.
+                    if a string is given its imported
 
     :param ignore: Ignore certain modules or packages during a scan. It
       should be a sequence containing strings and/or callables that
@@ -89,6 +90,11 @@ def scan(package, ignore=None, handle_error=None):
       ``handle_error`` does not re-raise the error, the error is
       suppressed.
     """
+    # module name instead of package object
+    if not hasattr(package, '__name__'):
+        __import__(package)
+        package = sys.modules[package]
+
     is_ignored = get_is_ignored(package, ignore)
 
     # not a package but a module

--- a/importscan/tests/test_importscan.py
+++ b/importscan/tests/test_importscan.py
@@ -174,3 +174,7 @@ def test_module_in_zipped():
     scan(moduleinzipped)
 
     assert fixtures.calls == 1
+
+
+def test_scan_from_name():
+    scan('email')


### PR DESCRIPTION
enables `scan(__name__)`