### PR TITLE
Fix missing py.typed marker in package data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include *.txt *.rst *.cfg *.py *.ini *.toml *.yaml
 exclude .installed.cfg
-recursive-include importscan *.py
+recursive-include importscan *.py py.typed
 recursive-include importscan/tests *.zip
 recursive-include doc *.rst Makefile *.py *.bat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ pyright = ["pyright", "pytest"]
 [tool.setuptools.packages]
 find = {}
 
+[tool.setuptools.package-data]
+importscan = ["py.typed"]
+
 [tool.setuptools.dynamic]
 readme = {file = ["README.rst", "CHANGES.txt"]}
 


### PR DESCRIPTION
I missed a small step in my original typing PR